### PR TITLE
Define Kibana password variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Elasticsearch and Kibana credentials
 ELASTIC_PWD=Changeme1  # Change this to your desired password for Elasticsearch
-KIBANA_PWD=Changeme1  # Change this to your desired password for Kibana
+KIBANA_PASSWORD=Changeme1  # Change this to your desired password for Kibana
 
 # Java memory options for Elasticsearch
 ES_JAVA_OPTS=-Xms1g -Xmx1g

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -1,7 +1,7 @@
 # ─── Core connection ──────────────────────────────────────────────
 elasticsearch.hosts: ["http://es01:9200"]
 elasticsearch.username: "kibana_system"
-elasticsearch.password: "${KIBANA_PWD}"
+elasticsearch.password: "${KIBANA_PASSWORD}"
 
 # ─── Disable TLS verification because ES is HTTP in dev ───────────
 elasticsearch.ssl.verificationMode: "none"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - discovery.type=zen-disco  # Zen Discovery for multi-node discovery
       - xpack.security.enabled=true
       - ELASTIC_PASSWORD=${ELASTIC_PWD:-Changeme1}
-      - KIBANA_PASSWORD=${KIBANA_PWD:-Changeme1}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD:-Changeme1}
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
     ulimits:
       memlock: { soft: -1, hard: -1 }
@@ -35,7 +35,7 @@ services:
       - discovery.type=zen-disco  # Zen Discovery for multi-node discovery
       - xpack.security.enabled=true
       - ELASTIC_PASSWORD=${ELASTIC_PWD:-Changeme1}
-      - KIBANA_PASSWORD=${KIBANA_PWD:-Changeme1}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD:-Changeme1}
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
     ulimits:
       memlock: { soft: -1, hard: -1 }
@@ -50,9 +50,11 @@ services:
   kibana:
     image: docker.io/library/kibana:8.18.0
     container_name: kib01
-    depends_on: 
+    depends_on:
       - elasticsearch
-    ports: 
+    environment:
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD:-Changeme1}
+    ports:
       - "5601:5601"
     volumes:
       - ./config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro  # Ensure kibana.yml is correctly mounted


### PR DESCRIPTION
## Summary
- fix Kibana startup error by defining the password env variable
- use a consistent `KIBANA_PASSWORD` variable across configs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778f2f9ef88330aa32ca2e514e05e7