### PR TITLE
Fix Kibana key length and discovery settings

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -8,7 +8,7 @@ elasticsearch.ssl.verificationMode: "none"
 
 # ─── Plug the “random key” warnings ───────────────────────────────
 xpack.security.encryptionKey: "aK3yThatIs32CharsLong1234567890"
-xpack.encryptedSavedObjects.encryptionKey: "32CharactersLongSoPickAnything!"
+xpack.encryptedSavedObjects.encryptionKey: "32CharactersLongSoPickAnything!!"
 xpack.reporting.encryptionKey: "another32charLongEncryptionKey!!!"
 
 # ─── Silence doc‑link task that spams ERROR on bad HTML ───────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - cluster.name=docker-cluster
       - discovery.seed_hosts=es02  # Inform ES01 about ES02
       - cluster.initial_master_nodes=es01,es02
-      - discovery.type=zen-disco  # Zen Discovery for multi-node discovery
       - xpack.security.enabled=true
       - ELASTIC_PASSWORD=${ELASTIC_PWD:-Changeme1}
       - KIBANA_PASSWORD=${KIBANA_PASSWORD:-Changeme1}
@@ -32,7 +31,6 @@ services:
       - cluster.name=docker-cluster
       - discovery.seed_hosts=es01  # Inform ES02 about ES01
       - cluster.initial_master_nodes=es01,es02
-      - discovery.type=zen-disco  # Zen Discovery for multi-node discovery
       - xpack.security.enabled=true
       - ELASTIC_PASSWORD=${ELASTIC_PWD:-Changeme1}
       - KIBANA_PASSWORD=${KIBANA_PASSWORD:-Changeme1}


### PR DESCRIPTION
## Summary
- fix the Kibana encrypted saved objects key length
- remove deprecated `discovery.type=zen-disco` from docker-compose

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877999a10e08330baccd9529fe21bd3