### PR TITLE
Fix kibana encryption key length

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -7,7 +7,7 @@ elasticsearch.password: "${KIBANA_PASSWORD}"
 elasticsearch.ssl.verificationMode: "none"
 
 # ─── Plug the “random key” warnings ───────────────────────────────
-xpack.security.encryptionKey: "aK3yThatIs32CharsLong1234567890"
+xpack.security.encryptionKey: "aK3yThatIs32CharsLong1234567890X"
 xpack.encryptedSavedObjects.encryptionKey: "32CharactersLongSoPickAnything!!"
 xpack.reporting.encryptionKey: "another32charLongEncryptionKey!!!"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   elasticsearch:


### PR DESCRIPTION
## Summary
- ensure kibana encryption key is at least 32 chars
- remove deprecated version field from docker compose

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779dfa71cc8330b6aa318247d901f4